### PR TITLE
Exit with exit code of 1 when an error is encountered

### DIFF
--- a/packages/react-percy-storybook/bin/percy-storybook.js
+++ b/packages/react-percy-storybook/bin/percy-storybook.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-const chalk = require('chalk');
-
 require('../lib/cli').run(process.argv.slice(2))
-    .then(() => process.on('exit', () => process.exit(0)))
+    .then(() => {
+      process.on('exit', () => process.exit(0));
+    })
     .catch((err) => {
         console.log('Error: ', err); // eslint-disable-line no-console
         process.on('exit', () => process.exit(1));

--- a/packages/react-percy-storybook/package.json
+++ b/packages/react-percy-storybook/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "@percy-io/react-percy-api-client": "^0.1.2",
-    "chalk": "^1.1.3",
     "debug": "^2.6.3",
     "es6-promise-pool": "^2.4.4",
     "jsdom": "^9.12.0",

--- a/packages/react-percy-storybook/src/__tests__/getStories-tests.js
+++ b/packages/react-percy-storybook/src/__tests__/getStories-tests.js
@@ -16,7 +16,9 @@ it('returns an empty array when no stories loaded', async () => {
     try {
         await getStories(code);
     } catch (e) {
-        expect(e).toEqual(new Error('Storybook object not found on window.'));
+        const message = 'Storybook object not found on window. Check '
+          + 'window.__storybook_stories__ is set in your Storybook\'s config.js.';
+        expect(e).toEqual(new Error(message));
     }
 
     expect.assertions(1);

--- a/packages/react-percy-storybook/src/getStories.js
+++ b/packages/react-percy-storybook/src/getStories.js
@@ -63,7 +63,9 @@ function getStoriesFromDom(previewJavascriptCode, options) {
             done: (err, window) => {
                 if (err) return reject(err.response.body);
                 if (!window || !window.__storybook_stories__) {
-                    reject(new Error('Storybook object not found on window.'));
+                    const message = 'Storybook object not found on window. Check '
+                        + 'window.__storybook_stories__ is set in your Storybook\'s config.js.';
+                    reject(new Error(message));
                 }
                 resolve(window.__storybook_stories__);
             }


### PR DESCRIPTION
percy-storybook errors such as missing environment variables or missing config adjustments now result in an exit code of 1.  One of the results of this correction is that CI will now show as failed if one of these errors is encountered.