### PR TITLE
Integration tests: Replace timemachine with mockdate

### DIFF
--- a/integration-tests/.storybook/config.js
+++ b/integration-tests/.storybook/config.js
@@ -1,21 +1,14 @@
 import { configure, getStorybook } from '@kadira/storybook';
 import inPercy from '@percy-io/in-percy';
 import faker from 'faker';
-
-// A warning about timemachine - it overides the current date when it's imported,
-// so be sure to call reset() if this isn't desired.
-import timemachine from 'timemachine';
+import mockdate from 'mockdate';
 
 // This demonstrates how to run code specifically for Percy's rendering environment
 if (inPercy()) {
   // Seed faker so it generates deterministic fake data
   faker.seed(123);
-  // Use timemachine to freeze the date to 2015
-  timemachine.config({
-    dateString: 'October 21, 2015 04:19:00'
-  });
-} else {
-  timemachine.reset(); // When we're not in Percy, don't override the current date.
+  // Mock the current date
+  mockdate.set('October 21, 2015 04:19:00');
 }
 
 function loadStories() {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -16,7 +16,7 @@
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-match-media": "^2.0.1",
-    "timemachine": "^0.3.0"
+    "mockdate": "^2.0.1"
   },
   "devDependencies": {
     "@kadira/storybook": "^2.35.3",

--- a/integration-tests/stories/index.js
+++ b/integration-tests/stories/index.js
@@ -23,11 +23,11 @@ storiesOf('Static CSS', module)
 storiesOf('Frozen Time', module)
     .add('Show the current date', () => (
         <div>
-            <p>In Percy&apos;s screenshot the current date should be frozen to 2015 thanks to timemachine.</p>
+            <p>In Percy&apos;s screenshot the current date should be frozen to 2015 thanks to mockdate.</p>
             <p>See .storybook/config.js or&nbsp;
-            <a href="https://www.npmjs.com/package/faker#setting-a-randomness-seed">
-              faker&apos;s docs
-            </a>
+                <a href="https://github.com/boblauer/MockDate">
+                  mockdate&apos;s docs
+                </a>
             &nbsp;for how it&apos;s configured.</p>
             <p>The current date is: {new Date().toLocaleDateString()}</p>
         </div>
@@ -41,8 +41,8 @@ storiesOf('Faker', module)
         <div>
             <p>In Percy&apos;s screenshot the fake data should be the same thanks to faker&apos;s seed.</p>
             <p>See .storybook/config.js or&nbsp;
-              <a href="https://www.npmjs.com/package/timemachine#config">
-                timemachine&apos;s docs
+              <a href="https://www.npmjs.com/package/faker#setting-a-randomness-seed">
+                faker&apos;s docs
               </a>
               &nbsp;for how it&apos;s configured.</p>
             <p>The name is: {name}</p>

--- a/integration-tests/yarn.lock
+++ b/integration-tests/yarn.lock
@@ -100,7 +100,7 @@
     webpack-hot-middleware "^2.13.2"
 
 "@percy-io/in-percy@file:../packages/in-percy":
-  version "0.1.0"
+  version "0.1.2"
 
 "@percy-io/react-percy-api-client@^0.1.2":
   version "0.1.2"
@@ -3397,6 +3397,10 @@ mobx@^2.3.4:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-2.7.0.tgz#cf3d82d18c0ca7f458d8f2a240817b3dc7e54a01"
 
+mockdate@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.1.tgz#51bc309e2c4396600d56b6c23a6a0f4182943a36"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -4935,10 +4939,6 @@ throat@^3.0.0:
 through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-
-timemachine@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/timemachine/-/timemachine-0.3.0.tgz#83e2eb696cbfe4696c1708e6a3700df4e62fc525"
 
 timers-browserify@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
mockdate behaves better in that it doesn't alter the current date just by being required.