### PR TITLE
register addons

### DIFF
--- a/integration-tests/.storybook/addons.js
+++ b/integration-tests/.storybook/addons.js
@@ -1,0 +1,4 @@
+import '@storybook/addon-actions/register';
+import '@storybook/addon-knobs/register';
+import '@storybook/addon-links/register';
+import '@storybook/addon-options/register';


### PR DESCRIPTION
I noticed that the addons weren't working properly, because they actually were never registered.

I noticed because the hierarchy separator was not actually working, it looks like this:

![storybook](https://user-images.githubusercontent.com/188038/28906835-b14393f4-785d-11e7-8ed4-f1799c2e92b8.png)

with this fix.

references #48 