### PR TITLE
Prevent Duplicate Snapshot Names

### DIFF
--- a/integration-tests/react-percy/__tests__/__snapshots__/basic-tests.js.snap
+++ b/integration-tests/react-percy/__tests__/__snapshots__/basic-tests.js.snap
@@ -16,15 +16,15 @@ Array [
     <body><div>This is some text</div></body>
     </html>
     ",
-        "id": "sha-/src__percy__redtext.percy.js:-redtext:-basic-components-work.html-sha",
+        "id": "sha-/redtext:-basic-components-work.html-sha",
         "isRoot": true,
         "mimetype": "text/html",
-        "resourceUrl": "/src__percy__redtext.percy.js:-redtext:-basic-components-work.html",
-        "sha": "sha-/src__percy__redtext.percy.js:-redtext:-basic-components-work.html-sha",
+        "resourceUrl": "/redtext:-basic-components-work.html",
+        "sha": "sha-/redtext:-basic-components-work.html-sha",
       },
     ],
     Object {
-      "name": "src/__percy__/RedText.percy.js: RedText: basic components work",
+      "name": "RedText: basic components work",
     },
   ],
   Array [
@@ -41,15 +41,15 @@ Array [
     <body><div>This is some text</div></body>
     </html>
     ",
-        "id": "sha-/src__percy__redtext.percy.js:-redtext:-components-with-custom-dimensions-work.html-sha",
+        "id": "sha-/redtext:-components-with-custom-dimensions-work.html-sha",
         "isRoot": true,
         "mimetype": "text/html",
-        "resourceUrl": "/src__percy__redtext.percy.js:-redtext:-components-with-custom-dimensions-work.html",
-        "sha": "sha-/src__percy__redtext.percy.js:-redtext:-components-with-custom-dimensions-work.html-sha",
+        "resourceUrl": "/redtext:-components-with-custom-dimensions-work.html",
+        "sha": "sha-/redtext:-components-with-custom-dimensions-work.html-sha",
       },
     ],
     Object {
-      "name": "src/__percy__/RedText.percy.js: RedText: components with custom dimensions work",
+      "name": "RedText: components with custom dimensions work",
       "widths": Array [
         320,
         768,
@@ -70,15 +70,15 @@ Array [
     <body><div>This is some text</div></body>
     </html>
     ",
-        "id": "sha-/src__percy__bluetext.percy.js:-basic-components-work.html-sha",
+        "id": "sha-/basic-components-work.html-sha",
         "isRoot": true,
         "mimetype": "text/html",
-        "resourceUrl": "/src__percy__bluetext.percy.js:-basic-components-work.html",
-        "sha": "sha-/src__percy__bluetext.percy.js:-basic-components-work.html-sha",
+        "resourceUrl": "/basic-components-work.html",
+        "sha": "sha-/basic-components-work.html-sha",
       },
     ],
     Object {
-      "name": "src/__percy__/BlueText.percy.js: basic components work",
+      "name": "basic components work",
     },
   ],
 ]

--- a/packages/react-percy-ci/src/Environment.js
+++ b/packages/react-percy-ci/src/Environment.js
@@ -1,5 +1,4 @@
 import createSuite from '@percy-io/react-percy-test-framework';
-import path from 'path';
 import vm from 'vm';
 
 const GLOBALS = [
@@ -33,7 +32,7 @@ export default class Environment {
       filename: file.path,
       displayErrors: true,
     });
-    await this.global.suite(path.relative(this.percyConfig.rootDir, file.path), () => {
+    await this.global.suite('', () => {
       script.runInContext(this.context, {
         displayErrors: true,
       });

--- a/packages/react-percy-ci/src/__tests__/Environment-tests.js
+++ b/packages/react-percy-ci/src/__tests__/Environment-tests.js
@@ -116,6 +116,6 @@ it('wraps script in a suite', async () => {
         `,
   });
 
-  expect(mockFrameworkGlobals.suite).toHaveBeenCalledWith('bar.percy.js', expect.any(Function));
+  expect(mockFrameworkGlobals.suite).toHaveBeenCalledWith('', expect.any(Function));
   expect(suiteSnapshots).toEqual(['snapshot']);
 });

--- a/packages/react-percy-test-framework/src/Snapshot.js
+++ b/packages/react-percy-test-framework/src/Snapshot.js
@@ -13,10 +13,6 @@ export default class Snapshot {
       throw new Error(`\`options\` should be an "object", but "${typeof options}" was given`);
     }
 
-    if (typeof fn !== 'function') {
-      throw new Error(`\`fn\` should be a "function", but "${typeof fn}" was given`);
-    }
-
     this.title = title;
     this.fn = fn;
     this.options = options || {};
@@ -45,6 +41,10 @@ export default class Snapshot {
   }
 
   async getSnapshot() {
+    if (!this.fn) {
+      return;
+    }
+
     return {
       name: this.fullTitle(),
       markup: await this.fn(),

--- a/packages/react-percy-test-framework/src/Suite.js
+++ b/packages/react-percy-test-framework/src/Suite.js
@@ -10,8 +10,8 @@ export default class Suite {
     this.title = title;
     this.options = options;
 
-    this.suites = {};
-    this.snapshots = {};
+    this.suites = [];
+    this.snapshots = [];
 
     this.beforeAll = [];
     this.beforeEach = [];
@@ -36,27 +36,13 @@ export default class Suite {
   }
 
   addSuite(suite) {
-    if (this.suites[suite.title]) {
-      if (!this.parent) {
-        throw new Error(`A suite with name ${suite.title} has already been added`);
-      } else {
-        throw new Error(
-          `A suite with title ${suite.title} has already been added to suite ${this.fullTitle()}`,
-        );
-      }
-    }
     suite.parent = this;
-    this.suites[suite.title] = suite;
+    this.suites.push(suite);
   }
 
   addSnapshot(snapshot) {
-    if (this.snapshots[snapshot.title]) {
-      throw new Error(
-        `A snapshot with name ${snapshot.title} has already been added to suite ${this.fullTitle()}`,
-      );
-    }
     snapshot.parent = this;
-    this.snapshots[snapshot.title] = snapshot;
+    this.snapshots.push(snapshot);
   }
 
   fullTitle() {
@@ -84,13 +70,13 @@ export default class Suite {
   async getSnapshots() {
     await each(fn => fn())(this.beforeAll);
 
-    const nestedSnapshots = await mapSeries(Object.values(this.suites), suite =>
+    const nestedSnapshots = await mapSeries(this.suites, suite =>
       suite.getSnapshots(),
     ).then(snapshots =>
       snapshots.reduce((accumulated, snapshots) => [...accumulated, ...snapshots], []),
     );
 
-    const snapshots = await mapSeries(Object.values(this.snapshots), async snapshot => {
+    const snapshots = await mapSeries(this.snapshots, async snapshot => {
       await this.runBeforeEach();
       const snapshotResult = await snapshot.getSnapshot();
       await this.runAfterEach();

--- a/packages/react-percy-test-framework/src/Suite.js
+++ b/packages/react-percy-test-framework/src/Suite.js
@@ -82,10 +82,11 @@ export default class Suite {
       await this.runAfterEach();
       return snapshotResult;
     });
+    const nonEmptySnapshots = snapshots.filter(snapshot => snapshot !== undefined);
 
     await each(fn => fn())(this.afterAll);
 
-    return [...nestedSnapshots, ...snapshots];
+    return [...nestedSnapshots, ...nonEmptySnapshots];
   }
 
   async runBeforeEach() {

--- a/packages/react-percy-test-framework/src/__tests__/Snapshot-tests.js
+++ b/packages/react-percy-test-framework/src/__tests__/Snapshot-tests.js
@@ -9,13 +9,17 @@ describe('constructor', () => {
   it('throws when no title is specified', () => {
     expect(() => new Snapshot(() => {})).toThrow();
   });
-
-  it('throws when title and options, but no function is specified', () => {
-    expect(() => new Snapshot('snapshot', { widths: [320, 1024] })).toThrow();
-  });
 });
 
 describe('getSnapshot', () => {
+  it('returns undefined given no function was specified', async () => {
+    const snapshot = new Snapshot('title');
+
+    const snapshotResult = await snapshot.getSnapshot();
+
+    expect(snapshotResult).toBeUndefined();
+  });
+
   it('sets name to title given no parent', async () => {
     const snapshot = new Snapshot('title', () => {});
 

--- a/packages/react-percy-test-framework/src/__tests__/Suite-getSnapshots-tests.js
+++ b/packages/react-percy-test-framework/src/__tests__/Suite-getSnapshots-tests.js
@@ -582,9 +582,38 @@ describe('snapshots', () => {
 
     expect(snapshotCases).toEqual([snapshotCase1, snapshotCase2]);
   });
+
+  it('filters out snapshots with no implementation', async () => {
+    const snapshotCase1 = {
+      title: 'snapshot 1',
+      markup: <div>Snapshot 1</div>,
+      options: {},
+    };
+    suite.addSnapshot({
+      title: 'snapshot 1',
+      getSnapshot: () => snapshotCase1,
+    });
+    suite.addSnapshot({
+      title: 'snapshot 2',
+      getSnapshot: () => undefined,
+    });
+    const snapshotCase3 = {
+      title: 'snapshot 3',
+      markup: <div>Snapshot 3</div>,
+      options: {},
+    };
+    suite.addSnapshot({
+      title: 'snapshot 3',
+      getSnapshot: () => snapshotCase3,
+    });
+
+    const snapshotCases = await suite.getSnapshots();
+
+    expect(snapshotCases).toEqual([snapshotCase1, snapshotCase3]);
+  });
 });
 
-it('nested suites', () => {
+describe('nested suites', () => {
   it('returns snapshot cases from nested suites', async () => {
     const snapshotCase = {
       title: 'snapshot',

--- a/packages/react-percy-test-framework/src/__tests__/Suite-tests.js
+++ b/packages/react-percy-test-framework/src/__tests__/Suite-tests.js
@@ -15,30 +15,9 @@ describe('addSuite', () => {
 
     expect(nestedSuite.parent).toEqual(suite);
   });
-
-  it('throws when suite with the same title has already been added', () => {
-    const suite = new Suite('parent');
-
-    const nestedSuite1 = new Suite('nested');
-    suite.addSuite(nestedSuite1);
-
-    const nestedSuite2 = new Suite('nested');
-    expect(() => suite.addSuite(nestedSuite2)).toThrow();
-  });
 });
 
 describe('addSnapshot', () => {
-  it('throws when snapshot with the same title has already been added', () => {
-    const suite = new Suite('title');
-    suite.parent = new Suite('parent');
-
-    const snapshot1 = { title: 'snapshot' };
-    suite.addSnapshot(snapshot1);
-
-    const snapshot2 = { title: 'snapshot' };
-    expect(() => suite.addSnapshot(snapshot2)).toThrow();
-  });
-
   it('sets parent on snapshot being added', () => {
     const suite = new Suite('title');
     suite.parent = new Suite('parent');

--- a/packages/react-percy-test-framework/src/interfaces/__tests__/__snapshots__/getCommonInterface-tests.js.snap
+++ b/packages/react-percy-test-framework/src/interfaces/__tests__/__snapshots__/getCommonInterface-tests.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshot throws if a snapshot with the same name has already been added to a different suite with the same name 1`] = `[Error: A snapshot named \`Suite: snapshot\` has already been added, please use a different name]`;

--- a/packages/react-percy-test-framework/src/interfaces/__tests__/getCommonInterface-tests.js
+++ b/packages/react-percy-test-framework/src/interfaces/__tests__/getCommonInterface-tests.js
@@ -175,7 +175,7 @@ describe('snapshot', () => {
     throw new Error('adding second snapshot should have thrown');
   });
 
-  it('does not throw if a snapshot with the same name has already been added to a different suite with the different name', async () => {
+  it('does not throw if a snapshot with the same name has already been added to a different suite with a different name', async () => {
     await common.suite('Suite 1', () => {
       common.snapshot('snapshot', jest.fn());
     });

--- a/packages/react-percy-test-framework/src/interfaces/__tests__/getCommonInterface-tests.js
+++ b/packages/react-percy-test-framework/src/interfaces/__tests__/getCommonInterface-tests.js
@@ -2,14 +2,18 @@ import getCommonInterface from '../getCommonInterface';
 import Snapshot from '../../Snapshot';
 import Suite from '../../Suite';
 
-jest.mock('../../Snapshot');
-jest.mock('../../Suite');
-
 let suites;
 let common;
 
 beforeEach(() => {
-  const rootSuite = new Suite();
+  const rootSuite = new Suite('');
+  jest.spyOn(rootSuite, 'addBeforeAll');
+  jest.spyOn(rootSuite, 'addBeforeEach');
+  jest.spyOn(rootSuite, 'addAfterEach');
+  jest.spyOn(rootSuite, 'addAfterAll');
+  jest.spyOn(rootSuite, 'addSuite');
+  jest.spyOn(rootSuite, 'addSnapshot');
+
   suites = [rootSuite];
   common = getCommonInterface(suites);
 });
@@ -142,6 +146,45 @@ describe('suite', () => {
 });
 
 describe('snapshot', () => {
+  it('throws if a snapshot with the same name has already been added to the current suite', () => {
+    common.snapshot('snapshot', jest.fn());
+
+    expect(() => common.snapshot('snapshot', jest.fn())).toThrow();
+  });
+
+  it('does not throw if a snapshot with a different name has already been added to the current suite', () => {
+    common.snapshot('snapshot 1', jest.fn());
+
+    expect(() => common.snapshot('snapshot 2', jest.fn())).not.toThrow();
+  });
+
+  it('throws if a snapshot with the same name has already been added to a different suite with the same name', async () => {
+    await common.suite('Suite', () => {
+      common.snapshot('snapshot', jest.fn());
+    });
+
+    try {
+      await common.suite('Suite', () => {
+        common.snapshot('snapshot', jest.fn());
+      });
+    } catch (e) {
+      expect(e).toMatchSnapshot();
+      return;
+    }
+
+    throw new Error('adding second snapshot should have thrown');
+  });
+
+  it('does not throw if a snapshot with the same name has already been added to a different suite with the different name', async () => {
+    await common.suite('Suite 1', () => {
+      common.snapshot('snapshot', jest.fn());
+    });
+
+    await common.suite('Suite 2', () => {
+      common.snapshot('snapshot', jest.fn());
+    });
+  });
+
   it('adds snapshot to the current suite', () => {
     common.snapshot('snapshot', jest.fn());
 

--- a/packages/react-percy-test-framework/src/interfaces/__tests__/getCommonInterface-tests.js
+++ b/packages/react-percy-test-framework/src/interfaces/__tests__/getCommonInterface-tests.js
@@ -55,13 +55,10 @@ describe('afterAll', () => {
 });
 
 describe('suite', () => {
-  it('rejects when no callback is specified', () => {
-    return common
-      .suite('suite')
-      .then(() => {
-        throw new Error('should have rejected');
-      })
-      .catch(e => expect(e).toBeInstanceOf(TypeError));
+  it('adds the suite as a child of the current suite given no callback', async () => {
+    await common.suite('suite');
+
+    expect(suites[0].addSuite).toHaveBeenCalledWith(expect.any(Suite));
   });
 
   it('adds the suite as a child of the current suite given synchronous callback', async () => {
@@ -75,6 +72,12 @@ describe('suite', () => {
     await common.suite('suite', fn);
 
     expect(suites[0].addSuite).toHaveBeenCalledWith(expect.any(Suite));
+  });
+
+  it('returns the new suite given no callback', async () => {
+    const newSuite = await common.suite('suite');
+
+    expect(newSuite).toEqual(expect.any(Suite));
   });
 
   it('returns the new suite given synchronous callback', async () => {

--- a/packages/react-percy-test-framework/src/interfaces/getCommonInterface.js
+++ b/packages/react-percy-test-framework/src/interfaces/getCommonInterface.js
@@ -2,6 +2,8 @@ import Snapshot from '../Snapshot';
 import Suite from '../Suite';
 
 export default function getCommonInterface(suites) {
+  const snapshotNames = {};
+
   return {
     beforeAll(fn) {
       suites[0].addBeforeAll(fn);
@@ -32,6 +34,13 @@ export default function getCommonInterface(suites) {
     snapshot(title, options, fn) {
       const snapshot = new Snapshot(title, options, fn);
       suites[0].addSnapshot(snapshot);
+      const snapshotFullTitle = snapshot.fullTitle();
+      if (snapshotNames[snapshotFullTitle]) {
+        throw new Error(
+          `A snapshot named \`${snapshotFullTitle}\` has already been added, please use a different name`,
+        );
+      }
+      snapshotNames[snapshotFullTitle] = true;
       return snapshot;
     },
   };

--- a/packages/react-percy-test-framework/src/interfaces/getCommonInterface.js
+++ b/packages/react-percy-test-framework/src/interfaces/getCommonInterface.js
@@ -25,8 +25,6 @@ export default function getCommonInterface(suites) {
       suites.unshift(suite);
       if (typeof fn === 'function') {
         await fn.call(suite);
-      } else {
-        throw new Error(`Suite "${suite.fullTitle()}" was defined but no callback was supplied.`);
       }
       suites.shift();
       return suite;


### PR DESCRIPTION
Summary
--
Several updates here related to how we handle suite and snapshot names.

1. Removed the file path from the final snapshot names. The file path was previously used as the name of the suites automatically wrapping each test file, but was a suboptimal solution aimed at preventing default snapshot names.
2. It's now perfectly okay to have two suites at the same level with the same name. As long as the snapshots within them do not share a name, there's no issue. Previously creating two suites at the same level with the same name would have thrown an error.
3. Moved the logic around such that duplicate snapshot name detection happens in one place at a global level rather than locally within each suite. Previously, we prevented duplicate snapshot names by having each suite ensure it contained no duplicate child suite names and no duplicate snapshot names. Now, `percySnapshot` function checks if a snapshot name has already been defined elsewhere and throws an error if so.
4. We now also simply ignore suites and snapshots with no callback defined (e.g. `percySnapshot('Button');`). Previously, if a user declared a new suite or snapshot but didn't provide a callback function it would blow up. Now we just ignore them and keep going, just as Jest and other test frameworks do with unimplemented tests.