### PR TITLE
[react-percy-storybook] Fix typings location for published package

### DIFF
--- a/packages/react-percy-storybook/package.json
+++ b/packages/react-percy-storybook/package.json
@@ -41,5 +41,5 @@
       "window": true
     }
   },
-  "typings": "src/react-percy-storybook.d.ts"
+  "typings": "lib/react-percy-storybook.d.ts"
 }


### PR DESCRIPTION
`src/` is not published to npm, but everything in `src/` is copied over to `lib/`, hence we need to adapt the typings location.

references #60 