### PR TITLE
Beta Fixes

### DIFF
--- a/packages/react-percy-ci/package.json
+++ b/packages/react-percy-ci/package.json
@@ -19,6 +19,7 @@
     "@percy-io/react-percy-api-client": "^0.2.0",
     "@percy-io/react-percy-test-framework": "^0.2.0",
     "@percy-io/react-percy-webpack": "^0.2.0",
+    "chalk": "^1.1.3",
     "debug": "^2.6.3",
     "jsdom": "^9.12.0"
   },

--- a/packages/react-percy-ci/src/reporter.js
+++ b/packages/react-percy-ci/src/reporter.js
@@ -1,0 +1,7 @@
+/* eslint-disable no-console */
+
+export default {
+  log(...args) {
+    console.log(...args);
+  },
+};

--- a/packages/react-percy-webpack/src/compile/createCompiler.js
+++ b/packages/react-percy-webpack/src/compile/createCompiler.js
@@ -29,16 +29,20 @@ export default function createCompiler(percyConfig, webpackConfig) {
           ],
         };
 
-  return webpack(
-    merge(webpackConfig, {
-      output: {
-        chunkFilename: '[name].chunk.js',
-        filename: '[name].js',
-        path: path.join(percyConfig.rootDir, 'static'),
-        publicPath: '/',
-      },
-      module,
-      plugins: [new MemoryOutputPlugin('/static/')],
-    }),
+  const mergedWebpackConfig = merge(webpackConfig, {
+    output: {
+      chunkFilename: '[name].chunk.js',
+      filename: '[name].js',
+      path: path.join(percyConfig.rootDir, 'static'),
+      publicPath: '/',
+    },
+    module,
+    plugins: [new MemoryOutputPlugin('/static/')],
+  });
+
+  mergedWebpackConfig.plugins = mergedWebpackConfig.plugins.filter(
+    plugin => !(plugin instanceof webpack.optimize.CommonsChunkPlugin),
   );
+
+  return webpack(mergedWebpackConfig);
 }

--- a/packages/react-percy-webpack/src/entry/writeRenderEntry.js
+++ b/packages/react-percy-webpack/src/entry/writeRenderEntry.js
@@ -18,7 +18,9 @@ export default function writeRenderEntry(percyConfig, filePath, resolver = requi
     const rootEl = document.getElementById("${RootElementId}");
 
     rootSuite.getSnapshotMarkup(snapshotName)
-      .then(markup => render(markup, rootEl));
+      .then(function(markup) {
+        return render(markup, rootEl);
+      });
   `,
   );
 }

--- a/packages/react-percy-webpack/src/entry/writeSnapshotsEntry.js
+++ b/packages/react-percy-webpack/src/entry/writeSnapshotsEntry.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 
-const getSuiteForFile = file => `global.suite('', () => require(${JSON.stringify(file)}));`;
+const getSuiteForFile = file =>
+  `global.suite('', function () { require(${JSON.stringify(file)}); });`;
 
 export default function writeSnapshotsEntry(snapshotFiles, filePath) {
   fs.writeFileSync(filePath, snapshotFiles.map(getSuiteForFile).join('\n'));

--- a/packages/react-percy/src/__tests__/cli-tests.js
+++ b/packages/react-percy/src/__tests__/cli-tests.js
@@ -43,6 +43,9 @@ beforeEach(() => {
 
   stdout = [];
   process.stdout.write = message => stdout.push(message);
+
+  process.env.PERCY_TOKEN = 'token';
+  process.env.PERCY_PROJECT = 'project';
 });
 
 it('shows help text given help arg', async () => {
@@ -75,6 +78,22 @@ it('exits with success code given version arg', async () => {
   await run();
 
   expect(process.exit).toHaveBeenCalledWith(0);
+});
+
+it('exits with error code given no PERCY_TOKEN environment variable', async () => {
+  delete process.env.PERCY_TOKEN;
+
+  await run();
+
+  expect(process.exit).toHaveBeenCalledWith(1);
+});
+
+it('exits with error code given no PERCY_PROJECT environment variable', async () => {
+  delete process.env.PERCY_PROJECT;
+
+  await run();
+
+  expect(process.exit).toHaveBeenCalledWith(1);
 });
 
 it('exits with success code given running succeeds', async () => {

--- a/packages/react-percy/src/__tests__/cli-tests.js
+++ b/packages/react-percy/src/__tests__/cli-tests.js
@@ -44,6 +44,7 @@ beforeEach(() => {
   stdout = [];
   process.stdout.write = message => stdout.push(message);
 
+  delete process.env.PERCY_ENABLE;
   process.env.PERCY_TOKEN = 'token';
   process.env.PERCY_PROJECT = 'project';
 });
@@ -74,6 +75,14 @@ it('prints the current `react-percy` version given version arg', async () => {
 
 it('exits with success code given version arg', async () => {
   argv.version = true;
+
+  await run();
+
+  expect(process.exit).toHaveBeenCalledWith(0);
+});
+
+it('exits with success code given PERCY_ENABLE environment variable is set to 0', async () => {
+  process.env.PERCY_ENABLE = 0;
 
   await run();
 

--- a/packages/react-percy/src/cli.js
+++ b/packages/react-percy/src/cli.js
@@ -30,6 +30,22 @@ export function run(argv, rootDir) {
     return;
   }
 
+  if (!process.env.PERCY_TOKEN) {
+    process.stdout.write(
+      chalk.bold.red('PERCY_TOKEN') + chalk.red(' environment variable must be set.'),
+    );
+    process.on('exit', () => process.exit(1));
+    return;
+  }
+
+  if (!process.env.PERCY_PROJECT) {
+    process.stdout.write(
+      chalk.bold.red('PERCY_PROJECT') + chalk.red(' environment variable must be set.'),
+    );
+    process.on('exit', () => process.exit(1));
+    return;
+  }
+
   const packageRoot = rootDir || process.cwd();
 
   const percyConfig = readPercyConfig(packageRoot);

--- a/packages/react-percy/src/cli.js
+++ b/packages/react-percy/src/cli.js
@@ -40,14 +40,8 @@ export function run(argv, rootDir) {
       process.on('exit', () => process.exit(0));
     })
     .catch(err => {
-      let formattedError;
-      try {
-        formattedError = err.stack || JSON.stringify(err);
-      } catch (e) {
-        formattedError = err;
-      }
       // eslint-disable-next-line no-console
-      console.log(chalk.bold.red(formattedError));
+      console.log(chalk.bold.red(err.stack || err));
       process.on('exit', () => process.exit(1));
     });
 }

--- a/packages/react-percy/src/cli.js
+++ b/packages/react-percy/src/cli.js
@@ -32,7 +32,7 @@ export function run(argv, rootDir) {
 
   if (!process.env.PERCY_TOKEN) {
     process.stdout.write(
-      chalk.bold.red('PERCY_TOKEN') + chalk.red(' environment variable must be set.'),
+      chalk.bold.red('PERCY_TOKEN') + chalk.red(' environment variable must be set.\n'),
     );
     process.on('exit', () => process.exit(1));
     return;
@@ -40,7 +40,7 @@ export function run(argv, rootDir) {
 
   if (!process.env.PERCY_PROJECT) {
     process.stdout.write(
-      chalk.bold.red('PERCY_PROJECT') + chalk.red(' environment variable must be set.'),
+      chalk.bold.red('PERCY_PROJECT') + chalk.red(' environment variable must be set.\n'),
     );
     process.on('exit', () => process.exit(1));
     return;

--- a/packages/react-percy/src/cli.js
+++ b/packages/react-percy/src/cli.js
@@ -57,7 +57,8 @@ export function run(argv, rootDir) {
     })
     .catch(err => {
       // eslint-disable-next-line no-console
-      console.log(chalk.bold.red(err.stack || err));
+      console.log(chalk.bold.red(err.stack || err.message || err));
+
       process.on('exit', () => process.exit(1));
     });
 }

--- a/packages/react-percy/src/cli.js
+++ b/packages/react-percy/src/cli.js
@@ -30,6 +30,12 @@ export function run(argv, rootDir) {
     return;
   }
 
+  if (process.env.PERCY_ENABLE === '0') {
+    process.stdout.write('Percy is disabled by PERCY_ENABLE=0 environment variable. Skipping.\n');
+    process.on('exit', () => process.exit(0));
+    return;
+  }
+
   if (!process.env.PERCY_TOKEN) {
     process.stdout.write(
       chalk.bold.red('PERCY_TOKEN') + chalk.red(' environment variable must be set.\n'),


### PR DESCRIPTION
Summary
--
Debugged the `buildkite/frontend` project and fixed all the remaining issues we were running into:
- Added some basic console logging so you can better see what's happening
- Better format errors
- Fail fast when percy token and project environment variables are not set
- Don't use arrow functions in code we inject to play better with various babel and node configurations
- Strip out `CommonsChunkPlugin` from webpack configs as it often relies on the original webpack config's `entry` definition, which we replace