### PR TITLE
Fix Test Environment Variables

### DIFF
--- a/integration-tests/react-percy/__tests__/react-percy-tests.js
+++ b/integration-tests/react-percy/__tests__/react-percy-tests.js
@@ -3,7 +3,11 @@ import * as percy from 'percy-client';
 import path from 'path';
 import { run } from '@percy-io/react-percy/lib/cli';
 
+process.env.PERCY_PROJECT = 'test/project';
+process.env.PERCY_TOKEN = 'fake token';
+
 jest.mock('percy-client');
+jest.mock('@percy-io/react-percy-ci/lib/reporter');
 
 // eslint-disable-next-line no-undef
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;


### PR DESCRIPTION
Summary
--
The `react-percy` CLI fails if the `PERCY_PROJECT` and `PERCY_TOKEN` environment variables aren't set. In CI we set them globally in Travis so everything works fine, but when running tests locally this was causing the integration tests to fail. This sets fake values for those environment variables within the tests so tests work locally as well.