### PR TITLE
Debug Mode + Bug Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ packages/*/lib
 
 # Packed npm
 *.tgz
+
+# Percy debug files
+.percy-debug

--- a/packages/react-percy-api-client/src/build/createBuild.js
+++ b/packages/react-percy-api-client/src/build/createBuild.js
@@ -15,7 +15,7 @@ export default function createBuild(percyClient, resources) {
           resolve(response.body.data);
         },
         err => {
-          debug('error creating build: %s (%s)', err.error, err.statusCode);
+          debug('error creating build: %o (%s)', err.error, err.statusCode);
           reject(err);
         },
       );

--- a/packages/react-percy-ci/src/index.js
+++ b/packages/react-percy-ci/src/index.js
@@ -16,6 +16,10 @@ const debug = createDebug('react-percy:ci');
 export default async function run(percyConfig, webpackConfig, percyToken) {
   const client = new ApiClient(percyToken);
 
+  if (percyConfig.debug) {
+    reporter.log(chalk.blue.bold('DEBUG MODE: No snapshots will be uploaded to Percy'));
+  }
+
   reporter.log('Compiling...');
   debug('compiling assets');
   const assets = await compileAssets(percyConfig, webpackConfig);
@@ -38,8 +42,8 @@ export default async function run(percyConfig, webpackConfig, percyToken) {
     const htmlPath = path.join(percyConfig.rootDir, '.percy-debug', 'index.html');
     fs.writeFileSync(htmlPath, html);
     reporter.log(
-      'Debug snapshots by opening %s in your browser and using the following query strings:',
-      chalk.blue(htmlPath),
+      'Debug snapshots by opening %s in your browser and appending the following query strings:',
+      chalk.blue.underline(`file://${htmlPath}`),
     );
     snapshots.sort().forEach(snapshot => {
       reporter.log(

--- a/packages/react-percy-ci/src/index.js
+++ b/packages/react-percy-ci/src/index.js
@@ -5,8 +5,10 @@ import createDebug from 'debug';
 import { EntryNames } from '@percy-io/react-percy-webpack';
 import Environment from './Environment';
 import findEntryPath from './findEntryPath';
+import fs from 'fs';
 import getHTML from './getHTML';
 import getQueryParamsForSnapshot from './getQueryParamsForSnapshot';
+import path from 'path';
 import reporter from './reporter';
 
 const debug = createDebug('react-percy:ci');
@@ -28,6 +30,24 @@ export default async function run(percyConfig, webpackConfig, percyToken) {
   debug('found snapshots %o', snapshots.map(snapshot => snapshot.name));
   if (!snapshots.length) {
     reporter.log(chalk.yellow.bold('No snapshots found'));
+    return;
+  }
+
+  if (percyConfig.debug) {
+    const html = getHTML(assets);
+    const htmlPath = path.join(percyConfig.rootDir, '.percy-debug', 'index.html');
+    fs.writeFileSync(htmlPath, html);
+    reporter.log(
+      'Debug snapshots by opening %s in your browser and using the following query strings:',
+      chalk.blue(htmlPath),
+    );
+    snapshots.sort().forEach(snapshot => {
+      reporter.log(
+        `  %s    ${chalk.green('?snapshot=%s')}`,
+        snapshot.name,
+        encodeURIComponent(snapshot.name),
+      );
+    });
     return;
   }
 

--- a/packages/react-percy-config/src/__tests__/normalize-tests.js
+++ b/packages/react-percy-config/src/__tests__/normalize-tests.js
@@ -2,6 +2,26 @@ import defaults from '../defaults';
 import normalize from '../normalize';
 import path from 'path';
 
+it('sets `debug` to false given `debug` mode is off', () => {
+  const config = {};
+  const packageRoot = '/package/root';
+  const debug = false;
+
+  const normalizedConfig = normalize(config, packageRoot, debug);
+
+  expect(normalizedConfig.debug).toBe(false);
+});
+
+it('sets `debug` to true given `debug` mode is on', () => {
+  const config = {};
+  const packageRoot = '/package/root';
+  const debug = true;
+
+  const normalizedConfig = normalize(config, packageRoot, debug);
+
+  expect(normalizedConfig.debug).toBe(true);
+});
+
 it('sets `includeFiles` to an empty array given no `includeFiles` in config', () => {
   const config = {};
   const packageRoot = '/package/root';

--- a/packages/react-percy-config/src/index.js
+++ b/packages/react-percy-config/src/index.js
@@ -2,8 +2,8 @@ import loadFromPackage from './loadFromPackage';
 import normalize from './normalize';
 import path from 'path';
 
-export default function readPercyConfig(packageRoot) {
+export default function readPercyConfig(packageRoot, debug) {
   const packageJsonPath = path.join(packageRoot, 'package.json');
   const config = loadFromPackage(packageJsonPath);
-  return normalize(config, packageRoot);
+  return normalize(config, packageRoot, debug);
 }

--- a/packages/react-percy-config/src/normalize.js
+++ b/packages/react-percy-config/src/normalize.js
@@ -1,8 +1,10 @@
 import defaults from './defaults';
 import path from 'path';
 
-export default function normalize(config, packageRoot) {
+export default function normalize(config, packageRoot, debug = false) {
   const normalizedConfig = {};
+
+  normalizedConfig.debug = debug;
 
   normalizedConfig.includeFiles = config.includeFiles || [];
 

--- a/packages/react-percy-test-framework/package.json
+++ b/packages/react-percy-test-framework/package.json
@@ -16,6 +16,7 @@
   ],
   "dependencies": {
     "babel-runtime": "^6.26.0",
+    "debug": "^2.6.3",
     "promise-each": "^2.2.0"
   },
   "devDependencies": {

--- a/packages/react-percy-test-framework/src/interfaces/__tests__/__snapshots__/getCommonInterface-tests.js.snap
+++ b/packages/react-percy-test-framework/src/interfaces/__tests__/__snapshots__/getCommonInterface-tests.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`snapshot throws if a snapshot with the same name has already been added to a different suite with the same name 1`] = `[Error: A snapshot named \`Suite: snapshot\` has already been added, please use a different name]`;
+exports[`snapshot throws if a snapshot with the same name has already been added to a different suite with the same name 1`] = `"A snapshot named \`Suite: snapshot\` has already been added, please use a different name"`;

--- a/packages/react-percy-test-framework/src/interfaces/__tests__/getCommonInterface-tests.js
+++ b/packages/react-percy-test-framework/src/interfaces/__tests__/getCommonInterface-tests.js
@@ -59,86 +59,46 @@ describe('afterAll', () => {
 });
 
 describe('suite', () => {
-  it('adds the suite as a child of the current suite given no callback', async () => {
-    await common.suite('suite');
+  it('adds the suite as a child of the current suite given no callback', () => {
+    common.suite('suite');
 
     expect(suites[0].addSuite).toHaveBeenCalledWith(expect.any(Suite));
   });
 
-  it('adds the suite as a child of the current suite given synchronous callback', async () => {
-    await common.suite('suite', jest.fn());
+  it('adds the suite as a child of the current suite given callback', () => {
+    common.suite('suite', jest.fn());
 
     expect(suites[0].addSuite).toHaveBeenCalledWith(expect.any(Suite));
   });
 
-  it('adds the suite as a child of the current suite given asynchronous callback', async () => {
-    const fn = () => new Promise(resolve => setTimeout(resolve, 1));
-    await common.suite('suite', fn);
-
-    expect(suites[0].addSuite).toHaveBeenCalledWith(expect.any(Suite));
-  });
-
-  it('returns the new suite given no callback', async () => {
-    const newSuite = await common.suite('suite');
+  it('returns the new suite given no callback', () => {
+    const newSuite = common.suite('suite');
 
     expect(newSuite).toEqual(expect.any(Suite));
   });
 
-  it('returns the new suite given synchronous callback', async () => {
-    const newSuite = await common.suite('suite', jest.fn());
+  it('returns the new suite given callback', () => {
+    const newSuite = common.suite('suite', jest.fn());
 
     expect(newSuite).toEqual(expect.any(Suite));
   });
 
-  it('returns the new suite given asynchronous callback', async () => {
-    const fn = () => new Promise(resolve => setTimeout(resolve, 1));
-    const newSuite = await common.suite('suite', fn);
-
-    expect(newSuite).toEqual(expect.any(Suite));
-  });
-
-  it('sets the new suite as the current suite while executing synchronous callback', async () => {
+  it('sets the new suite as the current suite while executing callback', () => {
     let callbackCurrentSuite;
     const callback = jest.fn(() => {
       callbackCurrentSuite = suites[0];
     });
 
-    const newSuite = await common.suite('suite', callback);
+    const newSuite = common.suite('suite', callback);
 
     expect(callbackCurrentSuite).toBe(newSuite);
     expect(callbackCurrentSuite).not.toBe(suites[0]);
   });
 
-  it('sets the new suite as the current suite while executing asynchronous callback', async () => {
-    let callbackCurrentSuite;
-    const callback = () =>
-      new Promise(resolve => {
-        setTimeout(() => {
-          callbackCurrentSuite = suites[0];
-          resolve();
-        }, 5);
-      });
-
-    const newSuite = await common.suite('suite', callback);
-
-    expect(callbackCurrentSuite).toBe(newSuite);
-    expect(callbackCurrentSuite).not.toBe(suites[0]);
-  });
-
-  it('restores the current suite after executing synchronous callback', async () => {
+  it('restores the current suite after executing callback', () => {
     const currentSuite = suites[0];
 
-    const newSuite = await common.suite('suite', jest.fn());
-
-    expect(suites[0]).toBe(currentSuite);
-    expect(suites[0]).not.toBe(newSuite);
-  });
-
-  it('restores the current suite after executing asynchronous callback', async () => {
-    const currentSuite = suites[0];
-    const fn = () => new Promise(resolve => setTimeout(resolve, 1));
-
-    const newSuite = await common.suite('suite', fn);
+    const newSuite = common.suite('suite', jest.fn());
 
     expect(suites[0]).toBe(currentSuite);
     expect(suites[0]).not.toBe(newSuite);
@@ -158,31 +118,28 @@ describe('snapshot', () => {
     expect(() => common.snapshot('snapshot 2', jest.fn())).not.toThrow();
   });
 
-  it('throws if a snapshot with the same name has already been added to a different suite with the same name', async () => {
-    await common.suite('Suite', () => {
+  it('throws if a snapshot with the same name has already been added to a different suite with the same name', () => {
+    common.suite('Suite', () => {
       common.snapshot('snapshot', jest.fn());
     });
 
-    try {
-      await common.suite('Suite', () => {
+    expect(() =>
+      common.suite('Suite', () => {
         common.snapshot('snapshot', jest.fn());
-      });
-    } catch (e) {
-      expect(e).toMatchSnapshot();
-      return;
-    }
-
-    throw new Error('adding second snapshot should have thrown');
+      }),
+    ).toThrowErrorMatchingSnapshot();
   });
 
-  it('does not throw if a snapshot with the same name has already been added to a different suite with a different name', async () => {
-    await common.suite('Suite 1', () => {
+  it('does not throw if a snapshot with the same name has already been added to a different suite with a different name', () => {
+    common.suite('Suite 1', () => {
       common.snapshot('snapshot', jest.fn());
     });
 
-    await common.suite('Suite 2', () => {
-      common.snapshot('snapshot', jest.fn());
-    });
+    expect(() =>
+      common.suite('Suite 2', () => {
+        common.snapshot('snapshot', jest.fn());
+      }),
+    ).not.toThrow();
   });
 
   it('adds snapshot to the current suite', () => {

--- a/packages/react-percy-test-framework/src/interfaces/getCommonInterface.js
+++ b/packages/react-percy-test-framework/src/interfaces/getCommonInterface.js
@@ -1,5 +1,8 @@
+import createDebug from 'debug';
 import Snapshot from '../Snapshot';
 import Suite from '../Suite';
+
+const debug = createDebug('react-percy:test-framework');
 
 export default function getCommonInterface(suites) {
   const snapshotNames = {};
@@ -17,7 +20,7 @@ export default function getCommonInterface(suites) {
     afterAll(fn) {
       suites[0].addAfterAll(fn);
     },
-    async suite(title, options, fn) {
+    suite(title, options, fn) {
       if (typeof fn === 'undefined') {
         fn = options;
         options = undefined;
@@ -25,8 +28,14 @@ export default function getCommonInterface(suites) {
       const suite = new Suite(title, options);
       suites[0].addSuite(suite);
       suites.unshift(suite);
+      if (suite.fullTitle()) {
+        debug('processing suite %o', suite.fullTitle());
+      }
       if (typeof fn === 'function') {
-        await fn.call(suite);
+        fn.call(suite);
+      }
+      if (suite.fullTitle()) {
+        debug('finished processing suite %o', suite.fullTitle());
       }
       suites.shift();
       return suite;
@@ -41,6 +50,7 @@ export default function getCommonInterface(suites) {
         );
       }
       snapshotNames[snapshotFullTitle] = true;
+      debug('added snapshot %o', snapshotFullTitle);
       return snapshot;
     },
   };

--- a/packages/react-percy-webpack/src/compile/__tests__/createCompiler-tests.js
+++ b/packages/react-percy-webpack/src/compile/__tests__/createCompiler-tests.js
@@ -29,6 +29,24 @@ beforeEach(() => {
   webpack.mockClear();
 });
 
+it('sets context to the project root directory', () => {
+  const percyConfig = {
+    rootDir: '/foo/bar',
+  };
+  const webpackConfig = {
+    context: '/some/other/context',
+    config: true,
+  };
+
+  createCompiler(percyConfig, webpackConfig);
+
+  expect(webpack).toHaveBeenCalledWith(
+    expect.objectContaining({
+      context: '/foo/bar',
+    }),
+  );
+});
+
 it('adds percy snapshot loader as a preloader given webpack 1', () => {
   detectWebpackVersion.mockReturnValue(1);
   const percyConfig = {

--- a/packages/react-percy-webpack/src/compile/__tests__/createCompiler-tests.js
+++ b/packages/react-percy-webpack/src/compile/__tests__/createCompiler-tests.js
@@ -1,5 +1,6 @@
 import createCompiler from '../createCompiler';
 import detectWebpackVersion from '../detectWebpackVersion';
+import path from 'path';
 import webpack from 'webpack';
 
 class WebpackCompiler {}
@@ -122,7 +123,7 @@ it('outputs to static folder given debug mode is off', () => {
   expect(webpack).toHaveBeenCalledWith(
     expect.objectContaining({
       output: expect.objectContaining({
-        path: '/foo/bar/static',
+        path: path.normalize('/foo/bar/static'),
       }),
     }),
   );
@@ -142,7 +143,7 @@ it('outputs to .percy-debug folder given debug mode is on', () => {
   expect(webpack).toHaveBeenCalledWith(
     expect.objectContaining({
       output: expect.objectContaining({
-        path: '/foo/bar/.percy-debug',
+        path: path.normalize('/foo/bar/.percy-debug'),
       }),
     }),
   );

--- a/packages/react-percy-webpack/src/compile/createCompiler.js
+++ b/packages/react-percy-webpack/src/compile/createCompiler.js
@@ -33,11 +33,13 @@ export default function createCompiler(percyConfig, webpackConfig) {
     output: {
       chunkFilename: '[name].chunk.js',
       filename: '[name].js',
-      path: path.join(percyConfig.rootDir, 'static'),
+      path: percyConfig.debug
+        ? path.join(percyConfig.rootDir, '.percy-debug')
+        : path.join(percyConfig.rootDir, 'static'),
       publicPath: '/',
     },
     module,
-    plugins: [new MemoryOutputPlugin('/static/')],
+    plugins: percyConfig.debug ? [] : [new MemoryOutputPlugin('/static/')],
   });
 
   mergedWebpackConfig.plugins = mergedWebpackConfig.plugins.filter(

--- a/packages/react-percy-webpack/src/compile/createCompiler.js
+++ b/packages/react-percy-webpack/src/compile/createCompiler.js
@@ -30,6 +30,7 @@ export default function createCompiler(percyConfig, webpackConfig) {
         };
 
   const mergedWebpackConfig = merge(webpackConfig, {
+    context: percyConfig.rootDir,
     output: {
       chunkFilename: '[name].chunk.js',
       filename: '[name].js',

--- a/packages/react-percy/package.json
+++ b/packages/react-percy/package.json
@@ -9,7 +9,7 @@
   "bugs": {
     "url": "https://github.com/percy/react-percy/issues"
   },
-  "homepage": "https://github.com/percy/react-percy",
+  "homepage": "https://percy.io/docs/clients/javascript/react",
   "license": "MIT",
   "engines": {
     "node": ">=4.0",

--- a/packages/react-percy/src/__tests__/cli-tests.js
+++ b/packages/react-percy/src/__tests__/cli-tests.js
@@ -97,12 +97,32 @@ it('exits with error code given no PERCY_TOKEN environment variable', async () =
   expect(process.exit).toHaveBeenCalledWith(1);
 });
 
+it('exits with success code given debug flag even with no PERCY_TOKEN environment variable', async () => {
+  argv.debug = true;
+  delete process.env.PERCY_TOKEN;
+  runPercy.mockImplementation(() => Promise.resolve());
+
+  await run();
+
+  expect(process.exit).toHaveBeenCalledWith(0);
+});
+
 it('exits with error code given no PERCY_PROJECT environment variable', async () => {
   delete process.env.PERCY_PROJECT;
 
   await run();
 
   expect(process.exit).toHaveBeenCalledWith(1);
+});
+
+it('exits with success code given debug flag even with no PERCY_PROJECT environment variable', async () => {
+  argv.debug = true;
+  delete process.env.PERCY_PROJECT;
+  runPercy.mockImplementation(() => Promise.resolve());
+
+  await run();
+
+  expect(process.exit).toHaveBeenCalledWith(0);
 });
 
 it('exits with success code given running succeeds', async () => {

--- a/packages/react-percy/src/args.js
+++ b/packages/react-percy/src/args.js
@@ -6,7 +6,8 @@ export const options = {
     description: 'Path to the webpack config file',
   },
   debug: {
-    description: 'Output Percy snapshots to disk for local debugging',
+    description:
+      'Output Percy snapshots to disk for local debugging; no snapshots will be uploaded to Percy',
     default: false,
     type: 'boolean',
   },

--- a/packages/react-percy/src/args.js
+++ b/packages/react-percy/src/args.js
@@ -5,6 +5,11 @@ export const options = {
     alias: 'c',
     description: 'Path to the webpack config file',
   },
+  debug: {
+    description: 'Output Percy snapshots to disk for local debugging',
+    default: false,
+    type: 'boolean',
+  },
 };
 
 export const usage = 'Usage: $0 --config=<webpackConfigPath>';

--- a/packages/react-percy/src/cli.js
+++ b/packages/react-percy/src/cli.js
@@ -11,7 +11,7 @@ const VERSION = require('../package.json').version;
 
 function formatError(error) {
   if (error.error && error.error.errors && error.error.errors.length) {
-    return error.error.errors.map(e => e.datail).join(', ');
+    return error.error.errors.map(e => e.detail).join(', ');
   }
   return error.stack || error;
 }
@@ -43,7 +43,7 @@ export function run(argv, rootDir) {
     return;
   }
 
-  if (!process.env.PERCY_TOKEN) {
+  if (!argv.debug && !process.env.PERCY_TOKEN) {
     process.stdout.write(
       chalk.bold.red('PERCY_TOKEN') + chalk.red(' environment variable must be set.\n'),
     );
@@ -51,7 +51,7 @@ export function run(argv, rootDir) {
     return;
   }
 
-  if (!process.env.PERCY_PROJECT) {
+  if (!argv.debug && !process.env.PERCY_PROJECT) {
     process.stdout.write(
       chalk.bold.red('PERCY_PROJECT') + chalk.red(' environment variable must be set.\n'),
     );
@@ -61,7 +61,7 @@ export function run(argv, rootDir) {
 
   const packageRoot = rootDir || process.cwd();
 
-  const percyConfig = readPercyConfig(packageRoot);
+  const percyConfig = readPercyConfig(packageRoot, argv.debug);
   const webpackConfig = readWebpackConfig(packageRoot, argv.config);
 
   return runPercy(percyConfig, webpackConfig, process.env.PERCY_TOKEN)


### PR DESCRIPTION
Summary
--
To make it easier to test out Percy locally on a repo, I've added a new `--debug` flag that writes the files to disk rather than uploading anything to Percy. You can then open the HTML file and append query params to preview different snapshots, mimicking what happens in Percy.

![image](https://user-images.githubusercontent.com/733696/30253933-22e13a62-965d-11e7-8c95-d30f4879c785.png)

![image](https://user-images.githubusercontent.com/733696/30253937-34f454fa-965d-11e7-9fe3-b238792c31c2.png)

I've been using this mode as I tinker with `material-ui` locally, and it helped me track down a bug. Previously `suite` supported an asynchronous callback function. But in practice I don't think it's actually useful and was causing some race conditions, so I've just dropped it. Now `suite` callbacks must be synchronous.