### PR TITLE
Webpack Fixes

### DIFF
--- a/packages/react-percy-webpack/src/compile/__tests__/createCompiler-tests.js
+++ b/packages/react-percy-webpack/src/compile/__tests__/createCompiler-tests.js
@@ -53,7 +53,14 @@ it('adds percy snapshot loader as a preloader given webpack 1', () => {
     rootDir: '/foo/bar',
   };
   const webpackConfig = {
-    config: true,
+    module: {
+      loaders: [
+        {
+          test: /\.js$/,
+          loader: 'babel-loader',
+        },
+      ],
+    },
   };
 
   createCompiler(percyConfig, webpackConfig);
@@ -73,13 +80,20 @@ it('adds percy snapshot loader as a preloader given webpack 1', () => {
   );
 });
 
-it('adds percy snapshot loader as a pre-enforced rule given webpack 2', () => {
+it('adds percy snapshot loader as a pre-enforced rule given webpack 2 config with rules', () => {
   detectWebpackVersion.mockReturnValue(2);
   const percyConfig = {
     rootDir: '/foo/bar',
   };
   const webpackConfig = {
-    config: true,
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          loader: 'babel-loader',
+        },
+      ],
+    },
   };
 
   createCompiler(percyConfig, webpackConfig);
@@ -100,13 +114,20 @@ it('adds percy snapshot loader as a pre-enforced rule given webpack 2', () => {
   );
 });
 
-it('adds percy snapshot loader as a pre-enforced rule given webpack 3', () => {
-  detectWebpackVersion.mockReturnValue(3);
+it('adds percy snapshot loader as a pre-enforced loader given webpack 2 config with loaders', () => {
+  detectWebpackVersion.mockReturnValue(2);
   const percyConfig = {
     rootDir: '/foo/bar',
   };
   const webpackConfig = {
-    config: true,
+    module: {
+      loaders: [
+        {
+          test: /\.js$/,
+          loader: 'babel-loader',
+        },
+      ],
+    },
   };
 
   createCompiler(percyConfig, webpackConfig);
@@ -114,7 +135,7 @@ it('adds percy snapshot loader as a pre-enforced rule given webpack 3', () => {
   expect(webpack).toHaveBeenCalledWith(
     expect.objectContaining({
       module: expect.objectContaining({
-        rules: expect.arrayContaining([
+        loaders: expect.arrayContaining([
           {
             test: /\.percy\.(js|jsx)/,
             exclude: /node_modules/,
@@ -205,7 +226,14 @@ it('adds percy snapshot babel loader given webpack 1', () => {
     rootDir: '/foo/bar',
   };
   const webpackConfig = {
-    config: true,
+    module: {
+      loaders: [
+        {
+          test: /\.js$/,
+          loader: 'babel-loader',
+        },
+      ],
+    },
   };
 
   createCompiler(percyConfig, webpackConfig);
@@ -228,13 +256,19 @@ it('adds percy snapshot babel loader given webpack 1', () => {
   );
 });
 
-it('adds percy snapshot babel loader given webpack 2', () => {
-  detectWebpackVersion.mockReturnValue(2);
+it('adds percy snapshot babel loader given webpack 2 config with rules', () => {
   const percyConfig = {
     rootDir: '/foo/bar',
   };
   const webpackConfig = {
-    config: true,
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          loader: 'babel-loader',
+        },
+      ],
+    },
   };
 
   createCompiler(percyConfig, webpackConfig);
@@ -259,13 +293,19 @@ it('adds percy snapshot babel loader given webpack 2', () => {
   );
 });
 
-it('adds percy snapshot babel loader given webpack 3', () => {
-  detectWebpackVersion.mockReturnValue(3);
+it('adds percy snapshot babel loader given webpack 2 config with loaders', () => {
   const percyConfig = {
     rootDir: '/foo/bar',
   };
   const webpackConfig = {
-    config: true,
+    module: {
+      loaders: [
+        {
+          test: /\.js$/,
+          loader: 'babel-loader',
+        },
+      ],
+    },
   };
 
   createCompiler(percyConfig, webpackConfig);
@@ -273,7 +313,7 @@ it('adds percy snapshot babel loader given webpack 3', () => {
   expect(webpack).toHaveBeenCalledWith(
     expect.objectContaining({
       module: expect.objectContaining({
-        rules: expect.arrayContaining([
+        loaders: expect.arrayContaining([
           {
             test: /\.percy\.(js|jsx)/,
             exclude: /node_modules/,

--- a/packages/react-percy-webpack/src/resolve/__tests__/getWebpackConfigExports-tests.js
+++ b/packages/react-percy-webpack/src/resolve/__tests__/getWebpackConfigExports-tests.js
@@ -38,3 +38,25 @@ it('returns ES6 config object', () => {
     config: true,
   });
 });
+
+it('returns ES5 config function', () => {
+  const config = getWebpackConfigExports(() => ({
+    config: true,
+  }));
+
+  expect(config).toEqual({
+    config: true,
+  });
+});
+
+it('returns ES6 config function', () => {
+  const config = getWebpackConfigExports({
+    default: () => ({
+      config: true,
+    }),
+  });
+
+  expect(config).toEqual({
+    config: true,
+  });
+});

--- a/packages/react-percy-webpack/src/resolve/getWebpackConfigExports.js
+++ b/packages/react-percy-webpack/src/resolve/getWebpackConfigExports.js
@@ -1,10 +1,14 @@
 export default function getWebpackConfigExports(webpackConfig) {
-  if (typeof webpackConfig !== 'object' || Array.isArray(webpackConfig)) {
-    throw new Error('Webpack config did not export an object');
+  if (Array.isArray(webpackConfig)) {
+    throw new Error('Percy does not support arrays of webpack configs');
   }
 
-  if (typeof webpackConfig.default === 'object') {
-    return getWebpackConfigExports(webpackConfig.default);
+  if (typeof webpackConfig.default !== 'undefined') {
+    webpackConfig = webpackConfig.default;
+  }
+
+  if (typeof webpackConfig === 'function') {
+    return webpackConfig();
   }
 
   return webpackConfig;


### PR DESCRIPTION
Summary
--
Addressing a couple of the Webpack bugs we've run into.
- Support Webpack v2+ configs that are still using `module.loaders` rather than `module.rules`.
- Support Webpack configs that export a function rather than an object.