### PR TITLE
When slugifying names to create urls, strip special characters

### DIFF
--- a/packages/react-percy-api-client/src/resources/__tests__/makeRootResource-tests.js
+++ b/packages/react-percy-api-client/src/resources/__tests__/makeRootResource-tests.js
@@ -21,6 +21,19 @@ it('sets resource URL to slug-ified snapshot name', () => {
   );
 });
 
+it('strips quotes from snapshot name when setting resource URL', () => {
+  const snapshotName = 'Suite - renders "my' + "' component";
+  const html = '<html></html>';
+
+  const rootResource = makeRootResource(percyClient, snapshotName, html);
+
+  expect(rootResource).toEqual(
+    expect.objectContaining({
+      resourceUrl: '/suite-renders-my-component.html',
+    }),
+  );
+});
+
 it('sets content to the HTML', () => {
   const snapshotName = 'Suite - renders my component';
   const html = '<html></html>';

--- a/packages/react-percy-api-client/src/resources/makeRootResource.js
+++ b/packages/react-percy-api-client/src/resources/makeRootResource.js
@@ -1,8 +1,8 @@
 import slugify from 'slugify';
 
 export default function makeRootResource(percyClient, name, html, encodedResourceParams) {
-  let slugified_name = slugify(name, { remove: /[$*_+~.()'"!\-:@]/g });
-  let resourceUrl = `/${slugified_name.toLowerCase()}.html`;
+  let slugifiedName = slugify(name, { remove: /[$*_+~.()'"!\-:@]/g });
+  let resourceUrl = `/${slugifiedName.toLowerCase()}.html`;
   if (encodedResourceParams) {
     resourceUrl = `${resourceUrl}?${encodedResourceParams}`;
   }

--- a/packages/react-percy-api-client/src/resources/makeRootResource.js
+++ b/packages/react-percy-api-client/src/resources/makeRootResource.js
@@ -1,7 +1,8 @@
 import slugify from 'slugify';
 
 export default function makeRootResource(percyClient, name, html, encodedResourceParams) {
-  let resourceUrl = `/${slugify(name, { remove: /[$*_+~.()'"!\-:@]/g }).toLowerCase()}.html`;
+  let slugified_name = slugify(name, { remove: /[$*_+~.()'"!\-:@]/g });
+  let resourceUrl = `/${slugified_name.toLowerCase()}.html`;
   if (encodedResourceParams) {
     resourceUrl = `${resourceUrl}?${encodedResourceParams}`;
   }

--- a/packages/react-percy-api-client/src/resources/makeRootResource.js
+++ b/packages/react-percy-api-client/src/resources/makeRootResource.js
@@ -1,7 +1,7 @@
 import slugify from 'slugify';
 
 export default function makeRootResource(percyClient, name, html, encodedResourceParams) {
-  let resourceUrl = `/${slugify(name).toLowerCase()}.html`;
+  let resourceUrl = `/${slugify(name, { remove: /[$*_+~.()'"!\-:@]/g }).toLowerCase()}.html`;
   if (encodedResourceParams) {
     resourceUrl = `${resourceUrl}?${encodedResourceParams}`;
   }


### PR DESCRIPTION
Sometimes names can have quotes in them, which if not stripped, were resulting in invalid urls.