### PR TITLE
Encode urls created from resource names

### DIFF
--- a/packages/react-percy-api-client/src/resources/__tests__/makeRootResource-tests.js
+++ b/packages/react-percy-api-client/src/resources/__tests__/makeRootResource-tests.js
@@ -21,15 +21,15 @@ it('sets resource URL to slug-ified snapshot name', () => {
   );
 });
 
-it('strips quotes from snapshot name when setting resource URL', () => {
-  const snapshotName = 'Suite - renders "my' + "' component";
+it('creates a safe url from snapshot name when setting resource URL', () => {
+  const snapshotName = 'Suite - renders "my' + "' component<>#%{}|\\^[]`;/?=&";
   const html = '<html></html>';
 
   const rootResource = makeRootResource(percyClient, snapshotName, html);
 
   expect(rootResource).toEqual(
     expect.objectContaining({
-      resourceUrl: '/suite-renders-my-component.html',
+      resourceUrl: "/suite-renders-%22my'-componentlessgreaterorand.html",
     }),
   );
 });

--- a/packages/react-percy-api-client/src/resources/makeRootResource.js
+++ b/packages/react-percy-api-client/src/resources/makeRootResource.js
@@ -1,8 +1,8 @@
 import slugify from 'slugify';
 
 export default function makeRootResource(percyClient, name, html, encodedResourceParams) {
-  let slugifiedName = slugify(name, { remove: /[$*_+~.()'"!\-:@]/g });
-  let resourceUrl = `/${slugifiedName.toLowerCase()}.html`;
+  let slugifiedName = slugify(name);
+  let resourceUrl = `/${encodeURI(slugifiedName.toLowerCase())}.html`;
   if (encodedResourceParams) {
     resourceUrl = `${resourceUrl}?${encodedResourceParams}`;
   }


### PR DESCRIPTION
The previous PR that added a remove regex replaced an undocumented regex that was already stripping other characters such as [ ], and therefore resulted us in creating other types of broken urls.

Fixing this now by encoding urls.