### PR TITLE
Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,12 @@
 [![Package Status](https://img.shields.io/npm/v/@percy/react.svg)](https://www.npmjs.com/package/@percy/react)
 [![Build Status](https://travis-ci.org/percy/react-percy.svg?branch=master)](https://travis-ci.org/percy/react-percy)
 
+### react-percy is deprecated
+
+The `react-percy` SDK has been deprecated in favor of our
+[Storybook](https://docs.percy.io/docs/storybook-for-react) or
+[Cypress](https://docs.percy.io/docs/cypress) SDKs. If you need help
+transitioning to a newer SDK feel free to [reach out to
+support](mailto:support@percy.io).
+
 #### Docs here: [https://docs.percy.io/v1/docs/react](https://docs.percy.io/v1/docs/react)


### PR DESCRIPTION
## What is this?

We have decided to deprecate the `react-percy` SDK since our newer SDKs cover the use cases better. 